### PR TITLE
Add PR support and tool-backed commit generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gityo
 
-`gityo` is a CLI that helps you stage changes, write or generate a commit message, commit, and optionally run a post-commit git action.
+`gityo` is a CLI that helps you stage changes, write or generate a commit message, commit, and optionally push or open a pull request.
 
 It is built for people who want a faster commit flow without turning git into a wall of commands.
 
@@ -21,8 +21,9 @@ npx gityo
 - lets you choose which changed files to stage
 - lets you write your own commit message
 - can generate a commit message with AI
+- can inspect files, staged diffs, GitHub issues, and docs while generating
 - creates the commit for you
-- can run a post-commit action like `git push`
+- can run a post-commit action like `git push` or `gh pr create`
 
 ## Quick use
 
@@ -46,6 +47,7 @@ gityo
 gityo --stage
 gityo --generate
 gityo --message "fix login redirect bug"
+gityo --pr main
 gityo --yolo
 ```
 
@@ -64,6 +66,8 @@ gityo --generate
 ```
 
 Supported providers include OpenAI, Anthropic, Google, OpenRouter, and compatible custom endpoints.
+
+When the staged diff is too large to send directly, gityo sends a compact diff summary first and lets the model inspect specific files, staged diffs, GitHub issues, and linked documentation with tools.
 
 ## Config
 
@@ -112,6 +116,7 @@ Example:
   },
   "autoAcceptMessage": false,
   "postCommand": "push",
+  "pullRequestBaseBranch": "main",
   "autoRunPostCommand": false,
   "instructions": "Write short, clear commit messages."
 }
@@ -135,8 +140,16 @@ A few useful examples:
 
 ```bash
 gityo config set postCommand push
+gityo config set postCommand push-and-pr
+gityo config set pullRequestBaseBranch main
 gityo config set autoRunPostCommand true
 gityo config set autoAcceptCommitMessage true
+```
+
+To create a pull request right after commit without changing config:
+
+```bash
+gityo --pr main
 ```
 
 ## Good for

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import { handleError } from './lib/handle-error'
 
 export const app = NoArg.create('gityo', {
   description:
-    'Stage changes, generate or enter a commit message, create a commit, and run a post-commit git command.',
+    'Stage changes, generate or enter a commit message, create a commit, and optionally push or open a pull request.',
 
   flags: {
     stage: NoArg.boolean()
@@ -26,6 +26,10 @@ export const app = NoArg.create('gityo', {
     post: NoArg.boolean()
       .aliases('p')
       .description('Run the post-commit git command without asking.'),
+
+    pr: NoArg.string().description(
+      'Create a pull request to the provided base branch after commit.'
+    ),
 
     yolo: NoArg.boolean()
       .aliases('y')

--- a/src/controllers/config-set.ts
+++ b/src/controllers/config-set.ts
@@ -13,6 +13,7 @@ export async function setConfigController(
   const key = keyArgument?.trim()
   const rawValue = valueArgument?.trim()
   const target = scope
+  const normalizedKey = key === 'customInstructions' ? 'instructions' : key
 
   if (!key) {
     throw new Error('Usage: config set <key> <value>')
@@ -23,13 +24,14 @@ export async function setConfigController(
   }
 
   if (
-    key !== 'autoAcceptCommitMessage' &&
-    key !== 'autoRunPostCommand' &&
-    key !== 'postCommand' &&
-    key !== 'customInstructions'
+    normalizedKey !== 'autoAcceptCommitMessage' &&
+    normalizedKey !== 'autoRunPostCommand' &&
+    normalizedKey !== 'postCommand' &&
+    normalizedKey !== 'pullRequestBaseBranch' &&
+    normalizedKey !== 'instructions'
   ) {
     throw new Error(
-      `Unsupported key '${key}'. Use autoAcceptCommitMessage, autoRunPostCommand, postCommand, customInstructions, or model.`
+      `Unsupported key '${key}'. Use autoAcceptCommitMessage, autoRunPostCommand, postCommand, pullRequestBaseBranch, instructions, or model.`
     )
   }
 
@@ -44,25 +46,39 @@ export async function setConfigController(
       ? ((await readProjectConfig(process.cwd())) ?? {})
       : ((await readGlobalConfig()) ?? {})
 
-  if (key === 'autoAcceptCommitMessage') {
+  if (normalizedKey === 'autoAcceptCommitMessage') {
     config.autoAcceptMessage = parseBoolean(rawValue)
   }
 
-  if (key === 'autoRunPostCommand') {
+  if (normalizedKey === 'autoRunPostCommand') {
     config.autoRunPostCommand = parseBoolean(rawValue)
   }
 
-  if (key === 'postCommand') {
-    if (rawValue !== 'push' && rawValue !== 'push-and-pull') {
-      throw new Error("Invalid postCommand. Use 'push' or 'push-and-pull'.")
+  if (normalizedKey === 'postCommand') {
+    if (
+      rawValue !== 'push' &&
+      rawValue !== 'push-and-pull' &&
+      rawValue !== 'push-and-pr'
+    ) {
+      throw new Error(
+        "Invalid postCommand. Use 'push', 'push-and-pull', or 'push-and-pr'."
+      )
     }
 
     config.postCommand = rawValue
   }
 
-  if (key === 'customInstructions') {
+  if (normalizedKey === 'pullRequestBaseBranch') {
     if (rawValue.length === 0) {
-      throw new Error('customInstructions cannot be empty.')
+      throw new Error('pullRequestBaseBranch cannot be empty.')
+    }
+
+    config.pullRequestBaseBranch = rawValue
+  }
+
+  if (normalizedKey === 'instructions') {
+    if (rawValue.length === 0) {
+      throw new Error('instructions cannot be empty.')
     }
 
     config.instructions = rawValue
@@ -74,7 +90,7 @@ export async function setConfigController(
     await writeGlobalConfig(config)
   }
 
-  console.log(`Updated ${key} in ${target} config.`)
+  console.log(`Updated ${normalizedKey} in ${target} config.`)
 }
 
 function parseBoolean(value: string) {

--- a/src/controllers/main.ts
+++ b/src/controllers/main.ts
@@ -23,6 +23,7 @@ type MainControllerOptions = {
   generate?: boolean
   message?: string
   post?: boolean
+  pr?: string
   stage?: boolean
   yolo?: boolean
 }
@@ -33,10 +34,16 @@ export async function mainController(options: MainControllerOptions = {}) {
 
   const repoRoot = await getRepositoryRoot(cwd)
   const config = await loadConfig(repoRoot)
+  const requestedPullRequestBaseBranch = options.pr?.trim()
 
   const forceStageEnabled = options.stage || options.yolo
   const forceLLMGenerate = options.generate || options.yolo
-  const forceExecPostCommand = options.post || options.yolo
+  const forceExecPostCommand =
+    options.post || options.yolo || Boolean(requestedPullRequestBaseBranch)
+
+  if (typeof options.pr === 'string' && !requestedPullRequestBaseBranch) {
+    throw new Error('The pull request base branch cannot be empty.')
+  }
 
   let finalCommitMessage = options.message?.trim() ?? ''
   if (typeof options.message === 'string' && finalCommitMessage.length === 0) {
@@ -132,18 +139,35 @@ export async function mainController(options: MainControllerOptions = {}) {
   await commitChanges(finalCommitMessage, repoRoot)
   console.log('')
 
-  if (!config.postCommand) {
+  const postCommand = requestedPullRequestBaseBranch
+    ? 'push-and-pr'
+    : config.postCommand
+
+  if (!postCommand) {
     return
   }
 
+  const pullRequestBaseBranch = requestedPullRequestBaseBranch
+    ? requestedPullRequestBaseBranch
+    : postCommand === 'push-and-pr'
+      ? config.pullRequestBaseBranch
+      : undefined
+
+  const postCommandLabel =
+    postCommand === 'push-and-pr' && pullRequestBaseBranch
+      ? `${postCommand} (${pullRequestBaseBranch})`
+      : postCommand
+
   if (forceExecPostCommand || config.autoRunPostCommand) {
-    console.log(chalk.yellow.dim(` Executing: ${config.postCommand}`))
+    console.log(chalk.yellow.dim(` Executing: ${postCommandLabel}`))
   } else {
-    const shouldRunPostCommand = await promptForPostCommand(config.postCommand)
+    const shouldRunPostCommand = await promptForPostCommand(postCommandLabel)
     if (!shouldRunPostCommand) {
       return
     }
   }
 
-  await runPostCommand(config.postCommand, repoRoot)
+  await runPostCommand(postCommand, repoRoot, {
+    pullRequestBaseBranch,
+  })
 }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -75,8 +75,49 @@ export async function stageFiles(files: string[], cwd = process.cwd()) {
   await runGit(['add', '--', ...files], cwd)
 }
 
-export async function getStagedDiff(cwd = process.cwd()) {
-  return (await runGit(['diff', '--cached', '--no-ext-diff'], cwd)).stdout
+export async function getStagedDiff(
+  cwd = process.cwd(),
+  options: {
+    files?: string[]
+    unified?: number
+  } = {}
+) {
+  const args = ['diff', '--cached', '--no-ext-diff', '--no-color']
+
+  if (typeof options.unified === 'number') {
+    args.push(`--unified=${Math.max(0, options.unified)}`)
+  }
+
+  if (options.files && options.files.length > 0) {
+    args.push('--', ...options.files)
+  }
+
+  return (await runGit(args, cwd)).stdout
+}
+
+export async function getStagedNameStatus(cwd = process.cwd()) {
+  return (
+    await runGit(
+      ['diff', '--cached', '--name-status', '--find-renames', '--no-ext-diff'],
+      cwd
+    )
+  ).stdout
+}
+
+export async function getStagedDiffStat(cwd = process.cwd()) {
+  return (
+    await runGit(
+      [
+        'diff',
+        '--cached',
+        '--stat',
+        '--summary',
+        '--find-renames',
+        '--no-ext-diff',
+      ],
+      cwd
+    )
+  ).stdout
 }
 
 export async function commitChanges(message: string, cwd = process.cwd()) {
@@ -88,19 +129,115 @@ export async function commitChanges(message: string, cwd = process.cwd()) {
 
 export async function runPostCommand(
   postCommand: ResolvedConfig['postCommand'],
-  cwd = process.cwd()
+  cwd = process.cwd(),
+  options: {
+    pullRequestBaseBranch?: string
+  } = {}
 ) {
-  await execa('git', ['push'], {
-    cwd,
-    stdio: 'inherit',
-  })
+  await pushCurrentBranch(cwd)
 
   if (postCommand === 'push-and-pull') {
     await execa('git', ['pull', '--rebase'], {
       cwd,
       stdio: 'inherit',
     })
+
+    return
   }
+
+  if (postCommand === 'push-and-pr') {
+    const baseBranch = options.pullRequestBaseBranch?.trim()
+
+    if (!baseBranch) {
+      throw new Error(
+        'A pull request base branch is required. Use --pr <branch> or set pullRequestBaseBranch in config.'
+      )
+    }
+
+    await createPullRequest(baseBranch, cwd)
+  }
+}
+
+export async function pushCurrentBranch(cwd = process.cwd()) {
+  const hasUpstream = await currentBranchHasUpstream(cwd)
+
+  if (hasUpstream) {
+    await execa('git', ['push'], {
+      cwd,
+      stdio: 'inherit',
+    })
+
+    return
+  }
+
+  const remote = await getDefaultRemote(cwd)
+  if (!remote) {
+    throw new Error('No git remote found to push the current branch.')
+  }
+
+  await execa('git', ['push', '--set-upstream', remote, 'HEAD'], {
+    cwd,
+    stdio: 'inherit',
+  })
+}
+
+export async function createPullRequest(
+  baseBranch: string,
+  cwd = process.cwd()
+) {
+  await execa('gh', ['pr', 'create', '--base', baseBranch, '--fill'], {
+    cwd,
+    stdio: 'inherit',
+  })
+}
+
+async function currentBranchHasUpstream(cwd: string) {
+  const result = await execa(
+    'git',
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    {
+      cwd,
+      reject: false,
+    }
+  )
+
+  return result.exitCode === 0
+}
+
+async function getDefaultRemote(cwd: string) {
+  const configuredRemote = await getConfiguredBranchRemote(cwd)
+  if (configuredRemote) {
+    return configuredRemote
+  }
+
+  const remotes = (await runGit(['remote'], cwd)).stdout
+    .split('\n')
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  if (remotes.includes('origin')) {
+    return 'origin'
+  }
+
+  return remotes[0]
+}
+
+async function getConfiguredBranchRemote(cwd: string) {
+  const branch = await getCurrentBranch(cwd)
+  if (branch === '(detached HEAD)') {
+    return undefined
+  }
+
+  const result = await execa(
+    'git',
+    ['config', '--get', `branch.${branch}.remote`],
+    {
+      cwd,
+      reject: false,
+    }
+  )
+
+  return result.exitCode === 0 ? result.stdout.trim() || undefined : undefined
 }
 
 async function runGit(args: string[], cwd: string) {

--- a/src/lib/llm/build-commit-message-context.ts
+++ b/src/lib/llm/build-commit-message-context.ts
@@ -1,0 +1,121 @@
+import { getStagedDiff, getStagedDiffStat, getStagedNameStatus } from '../git'
+
+const MAX_COMPACT_DIFF_CHARS = 24000
+const MAX_CHANGED_LINES_PER_HUNK = 8
+const MAX_HUNKS_PER_FILE = 8
+
+export async function buildCommitMessageContext(cwd: string) {
+  const [nameStatus, diffStat, compactDiff] = await Promise.all([
+    getStagedNameStatus(cwd),
+    getStagedDiffStat(cwd),
+    getCompactStagedDiff(cwd),
+  ])
+
+  return [
+    'Staged file changes:',
+    nameStatus.trim() || '(none)',
+    '',
+    'Diff summary:',
+    diffStat.trim() || '(none)',
+    '',
+    'Compact staged diff:',
+    compactDiff,
+  ].join('\n')
+}
+
+async function getCompactStagedDiff(cwd: string) {
+  const diff = (await getStagedDiff(cwd, { unified: 0 })).trim()
+
+  if (diff.length === 0) {
+    return '(empty staged diff)'
+  }
+
+  if (diff.length <= MAX_COMPACT_DIFF_CHARS) {
+    return diff
+  }
+
+  const sections = splitDiffSections(diff)
+  const compactSections: string[] = []
+  let totalLength = 0
+
+  for (const section of sections) {
+    const compactSection = compactDiffSection(section)
+    if (!compactSection) {
+      continue
+    }
+
+    if (totalLength + compactSection.length > MAX_COMPACT_DIFF_CHARS) {
+      break
+    }
+
+    compactSections.push(compactSection)
+    totalLength += compactSection.length + 2
+  }
+
+  if (compactSections.length === 0) {
+    return truncateText(diff, MAX_COMPACT_DIFF_CHARS)
+  }
+
+  return `${compactSections.join('\n\n')}\n\n[diff truncated; use tools for more context]`
+}
+
+function splitDiffSections(diff: string) {
+  return diff
+    .split('\ndiff --git ')
+    .map((section, index) => (index === 0 ? section : `diff --git ${section}`))
+}
+
+function compactDiffSection(section: string) {
+  const lines = section.split('\n')
+  const header: string[] = []
+  const hunks: string[][] = []
+  let currentHunk: string[] | null = null
+
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      currentHunk = [line]
+      hunks.push(currentHunk)
+      continue
+    }
+
+    if (!currentHunk) {
+      header.push(line)
+      continue
+    }
+
+    if (
+      (line.startsWith('+') || line.startsWith('-')) &&
+      !line.startsWith('+++') &&
+      !line.startsWith('---')
+    ) {
+      currentHunk.push(line)
+    }
+  }
+
+  const output = [...header]
+
+  for (const hunk of hunks.slice(0, MAX_HUNKS_PER_FILE)) {
+    output.push(hunk[0])
+    output.push(...hunk.slice(1, 1 + MAX_CHANGED_LINES_PER_HUNK))
+
+    const omittedLineCount = hunk.length - 1 - MAX_CHANGED_LINES_PER_HUNK
+    if (omittedLineCount > 0) {
+      output.push(`[...${omittedLineCount} more changed lines omitted]`)
+    }
+  }
+
+  const omittedHunkCount = hunks.length - MAX_HUNKS_PER_FILE
+  if (omittedHunkCount > 0) {
+    output.push(`[...${omittedHunkCount} more hunks omitted]`)
+  }
+
+  return output.join('\n').trim()
+}
+
+function truncateText(value: string, maxLength: number) {
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  return `${value.slice(0, Math.max(0, maxLength - 21))}\n[output truncated...]`
+}

--- a/src/lib/llm/create-commit-message-tools.ts
+++ b/src/lib/llm/create-commit-message-tools.ts
@@ -1,0 +1,268 @@
+import { tool } from 'ai'
+import { execa } from 'execa'
+import { readFile, readdir, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { z } from 'zod'
+import { getStagedDiff } from '../git'
+
+const MAX_FILE_CONTENT_CHARS = 12000
+const MAX_DIRECTORY_ENTRIES = 200
+const MAX_FETCH_CONTENT_CHARS = 12000
+const MAX_DIFF_CONTENT_CHARS = 12000
+const MAX_COMMAND_OUTPUT_CHARS = 12000
+
+export function createCommitMessageTools(repoRoot: string) {
+  return {
+    read_files: tool({
+      description: 'Read one or more UTF-8 files from the repository.',
+      inputSchema: z.object({
+        paths: z.array(z.string().min(1)).min(1).max(5),
+      }),
+      execute: async ({ paths }) => ({
+        files: await Promise.all(
+          paths.map((currentPath) => readRepoFile(repoRoot, currentPath))
+        ),
+      }),
+    }),
+
+    read_directories: tool({
+      description: 'List files and folders in repository directories.',
+      inputSchema: z.object({
+        paths: z.array(z.string().min(1)).min(1).max(5),
+      }),
+      execute: async ({ paths }) => ({
+        directories: await Promise.all(
+          paths.map((currentPath) => readRepoDirectory(repoRoot, currentPath))
+        ),
+      }),
+    }),
+
+    read_staged_diffs: tool({
+      description: 'Read staged git diffs for specific repository files.',
+      inputSchema: z.object({
+        paths: z.array(z.string().min(1)).min(1).max(5),
+      }),
+      execute: async ({ paths }) => ({
+        diffs: await Promise.all(
+          paths.map((currentPath) => readRepoDiff(repoRoot, currentPath))
+        ),
+      }),
+    }),
+
+    fetch: tool({
+      description: 'Fetch a public HTTPS URL as text.',
+      inputSchema: z.object({
+        url: z.url(),
+      }),
+      execute: async ({ url }) => fetchUrl(url),
+    }),
+
+    gh: tool({
+      description:
+        'Run a read-only gh command for issues, pull requests, or repository metadata.',
+      inputSchema: z.object({
+        args: z.array(z.string().min(1)).min(1).max(12),
+      }),
+      execute: async ({ args }) => runGhCommand(repoRoot, args),
+    }),
+  }
+}
+
+async function readRepoFile(repoRoot: string, userPath: string) {
+  try {
+    const absolutePath = resolveRepoPath(repoRoot, userPath)
+    const fileStat = await stat(absolutePath)
+
+    if (!fileStat.isFile()) {
+      return {
+        path: normalizeRepoPath(repoRoot, absolutePath),
+        error: 'Path is not a file.',
+      }
+    }
+
+    const content = await readFile(absolutePath, 'utf8')
+
+    return {
+      path: normalizeRepoPath(repoRoot, absolutePath),
+      content: truncateText(content, MAX_FILE_CONTENT_CHARS),
+    }
+  } catch (error) {
+    return {
+      path: userPath,
+      error: toErrorMessage(error),
+    }
+  }
+}
+
+async function readRepoDirectory(repoRoot: string, userPath: string) {
+  try {
+    const absolutePath = resolveRepoPath(repoRoot, userPath)
+    const directoryStat = await stat(absolutePath)
+
+    if (!directoryStat.isDirectory()) {
+      return {
+        path: normalizeRepoPath(repoRoot, absolutePath),
+        error: 'Path is not a directory.',
+      }
+    }
+
+    const entries = await readdir(absolutePath, { withFileTypes: true })
+
+    return {
+      path: normalizeRepoPath(repoRoot, absolutePath),
+      entries: entries
+        .slice(0, MAX_DIRECTORY_ENTRIES)
+        .map((entry) => `${entry.name}${entry.isDirectory() ? '/' : ''}`),
+      truncated: entries.length > MAX_DIRECTORY_ENTRIES,
+    }
+  } catch (error) {
+    return {
+      path: userPath,
+      error: toErrorMessage(error),
+    }
+  }
+}
+
+async function readRepoDiff(repoRoot: string, userPath: string) {
+  try {
+    const absolutePath = resolveRepoPath(repoRoot, userPath)
+    const relativePath = normalizeRepoPath(repoRoot, absolutePath)
+    const diff = await getStagedDiff(repoRoot, {
+      unified: 0,
+      files: [relativePath],
+    })
+
+    return {
+      path: relativePath,
+      diff: truncateText(
+        diff.trim() || '(no staged diff)',
+        MAX_DIFF_CONTENT_CHARS
+      ),
+    }
+  } catch (error) {
+    return {
+      path: userPath,
+      error: toErrorMessage(error),
+    }
+  }
+}
+
+async function fetchUrl(url: string) {
+  const targetUrl = new URL(url)
+  if (targetUrl.protocol !== 'https:') {
+    return {
+      url,
+      error: 'Only HTTPS URLs are supported.',
+    }
+  }
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: {
+        'user-agent': 'gityo',
+      },
+      signal: AbortSignal.timeout(10000),
+    })
+
+    const text = await response.text()
+
+    return {
+      url,
+      status: response.status,
+      content: truncateText(text, MAX_FETCH_CONTENT_CHARS),
+    }
+  } catch (error) {
+    return {
+      url,
+      error: toErrorMessage(error),
+    }
+  }
+}
+
+async function runGhCommand(repoRoot: string, args: string[]) {
+  if (!isReadOnlyGhCommand(args)) {
+    return {
+      command: `gh ${args.join(' ')}`,
+      error:
+        'Only read-only gh commands are supported: issue view/list, pr view/list, repo view, and api GET.',
+    }
+  }
+
+  const result = await execa('gh', args, {
+    cwd: repoRoot,
+    reject: false,
+  })
+
+  return {
+    command: `gh ${args.join(' ')}`,
+    ok: result.exitCode === 0,
+    output: truncateText(
+      result.stdout || result.stderr || '(no output)',
+      MAX_COMMAND_OUTPUT_CHARS
+    ),
+  }
+}
+
+function isReadOnlyGhCommand(args: string[]) {
+  const [command, subcommand] = args
+
+  if (command === 'issue' || command === 'pr') {
+    return subcommand === 'view' || subcommand === 'list'
+  }
+
+  if (command === 'repo') {
+    return subcommand === 'view'
+  }
+
+  if (command !== 'api') {
+    return false
+  }
+
+  for (let index = 1; index < args.length; index += 1) {
+    const value = args[index]
+
+    if (value === '-X') {
+      return args[index + 1]?.toUpperCase() === 'GET'
+    }
+
+    if (
+      value === '--method' ||
+      value === '--input' ||
+      value === '--field' ||
+      value === '-f' ||
+      value === '--raw-field' ||
+      value === '-F'
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function resolveRepoPath(repoRoot: string, userPath: string) {
+  const absolutePath = path.resolve(repoRoot, userPath)
+  const relativePath = path.relative(repoRoot, absolutePath)
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error('Path must stay inside the repository root.')
+  }
+
+  return absolutePath
+}
+
+function normalizeRepoPath(repoRoot: string, absolutePath: string) {
+  return path.relative(repoRoot, absolutePath).split(path.sep).join('/') || '.'
+}
+
+function truncateText(value: string, maxLength: number) {
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  return `${value.slice(0, Math.max(0, maxLength - 21))}\n[output truncated...]`
+}
+
+function toErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Unknown error'
+}

--- a/src/lib/llm/generate-commit-message.ts
+++ b/src/lib/llm/generate-commit-message.ts
@@ -1,7 +1,8 @@
 import type { OpenAICompatibleProviderOptions } from '@ai-sdk/openai-compatible'
-import { generateText } from 'ai'
+import { generateText, stepCountIs } from 'ai'
 import { SUPPORTED_PROVIDERS, type ResolvedConfig } from '../../schema'
-import { getStagedDiff } from '../git'
+import { buildCommitMessageContext } from './build-commit-message-context'
+import { createCommitMessageTools } from './create-commit-message-tools'
 import { resolveAiProvider } from './resolve-provider'
 import systemPrompt from './system-prompt.txt?raw'
 
@@ -23,8 +24,11 @@ export async function generateCommitMessage(
     )
   }
 
+  const stagedContext = await buildCommitMessageContext(cwd)
+
   const result = await generateText({
     model: provider(model.name),
+    stopWhen: stepCountIs(6),
 
     messages: [
       {
@@ -33,15 +37,14 @@ export async function generateCommitMessage(
       },
       {
         role: 'user',
-        content: `Staged diff:\n${await getStagedDiff(cwd)}`,
-      },
-      {
-        role: 'user',
-        content:
+        content: `Generate a concise git commit message for the currently staged changes.\n\n${stagedContext}\n\nAdditional instructions:\n${
           config.instructions ||
-          'Generate a concise git commit message based on the above instructions and diff.',
+          'Generate a concise git commit message based on the staged changes.'
+        }\n\nUse the available tools when you need more detail about specific files, diffs, GitHub issues, or linked documentation.`,
       },
     ],
+
+    tools: createCommitMessageTools(cwd),
 
     providerOptions: {
       openai: {

--- a/src/lib/llm/system-prompt.txt
+++ b/src/lib/llm/system-prompt.txt
@@ -17,6 +17,7 @@ STRICT RULES:
 8. MUST NOT use vague terms like "Update", "Fix stuff", "Changes"
 9. If including a body, MUST have exactly one blank line between subject and body
 10. Body lines MUST wrap at 72 characters
+11. If the provided context is not enough, inspect the repository with tools before answering
 
 OUTPUT INSTRUCTION:
 Return ONLY the commit message. No explanations, no extra text, no markdown formatting.

--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -16,7 +16,7 @@ export async function loadConfig(cwd = process.cwd()) {
   return resolveConfig({
     ...(globalConfig ?? {}),
     ...(projectConfig ?? {}),
-    customInstructions:
+    instructions:
       projectInstructions ??
       projectConfig?.instructions ??
       globalConfig?.instructions,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,6 +6,8 @@ export const SUPPORTED_PROVIDERS = [
   ...BUILTIN_PROVIDERS,
   ...COMPATIBLE_PROVIDERS,
 ] as const
+export const POST_COMMANDS = ['push', 'push-and-pull', 'push-and-pr'] as const
+export type PostCommand = (typeof POST_COMMANDS)[number] | null
 
 export const configSchema = z
   .object({
@@ -25,13 +27,16 @@ export const configSchema = z
     autoAcceptMessage: z.boolean(),
     instructions: z.string().min(1),
 
-    postCommand: z.enum(['push', 'push-and-pull']).nullable(),
+    postCommand: z.enum(POST_COMMANDS).nullable(),
+    pullRequestBaseBranch: z.string().min(1),
     autoRunPostCommand: z.boolean(),
   })
   .partial()
 
 export function resolveConfig(input: unknown) {
   const parsed = configSchema.parse(input)
+  const postCommand: PostCommand =
+    parsed.postCommand === undefined ? 'push' : parsed.postCommand
 
   return {
     model: parsed.model,
@@ -39,8 +44,9 @@ export function resolveConfig(input: unknown) {
     instructions: parsed.instructions,
     autoAcceptCommitMessage: parsed.autoAcceptMessage ?? false,
 
-    postCommand:
-      parsed.postCommand === undefined ? ('push' as const) : parsed.postCommand,
+    postCommand,
+
+    pullRequestBaseBranch: parsed.pullRequestBaseBranch,
 
     autoRunPostCommand: parsed.autoRunPostCommand ?? false,
   }


### PR DESCRIPTION
## Summary
- add `--pr <base>` support plus a `push-and-pr` post-command and `pullRequestBaseBranch` config
- switch commit generation to compact staged-diff context with read-only file, diff, fetch, and `gh` tools to avoid oversized prompt failures on large changes
- pass repo instructions through correctly from `.gityo.md` and update the README for the new workflow

## Testing
- `nr lint`
- `nr build`

## Issues
- Closes #3
- Closes #4
- Closes #6